### PR TITLE
reverse to new msalclient after lint changes

### DIFF
--- a/graph-tutorial/src/addin/consent.js
+++ b/graph-tutorial/src/addin/consent.js
@@ -13,7 +13,7 @@ var msal = msal || {
   },
 };
 
-const msalClient = msal.PublicClientApplication({
+const msalClient = new msal.PublicClientApplication({
   auth: {
     // authConfig is defined in config.js
     // @ts-ignore


### PR DESCRIPTION
It did work for me once but almost always it fails with this error:
```
consent.js:53  Uncaught TypeError: msalClient.handleRedirectPromise is not a function
    at consent.js:53:8
    at office.debug.js:1714:34
    at setOfficeJsAsLoadedAndDispatchPendingOnReadyCallbacks (office.debug.js:1692:50)
    at office.debug.js:2022:33
    at validateFunction (office.debug.js:386:21)
    at LoadScriptHelper.waitForFunction (office.debug.js:398:13)
    at OutlookAppOm.appReady [as appReadyCallback] (office.debug.js:2001:43)
    at outlook-win32-16.02.debug.js:16454:26

Verify error: {"name":"JsonWebTokenError","message":"jwt must be provided"}
``
